### PR TITLE
Fixes #11 - Fail blocks are now defined with their index as name.

### DIFF
--- a/metac-err/__tests__/stack.mc
+++ b/metac-err/__tests__/stack.mc
@@ -7,12 +7,12 @@ int32 stack[10];
 // pointer contains the next write position
 int32 sptr = 0;
 // define errors
-typedef enum {empty} empty_error;
-typedef enum {full} full_error;
+enum empty_error {empty};
+enum full_error {full};
 // add a value to the stack.
 // this MaybeError<void> is a parameterized type. C doesn't know this
 // kind of types at all, so this needs some hard-coding or bike-shedding.
-MaybeError<void,stack_error> push(int32 x) {
+MaybeError<void, enum empty_error> push(int32 x) {
   if (sptr < SIZE) {
     stack[sptr++] = x; // success, return void
   } else {
@@ -20,8 +20,9 @@ MaybeError<void,stack_error> push(int32 x) {
     return Error(full);
   }
 }
+
 // get the latest value, if one exists
-MaybeError<int32,stack_error> pop() {
+MaybeError<int32, enum empty_error> pop() {
   if (sptr > 0) {
     return stack[--sptr];
   } else {
@@ -41,9 +42,9 @@ void main() {
     printf("%d\n", last1); // and use directly
     int32 last2 ?= pop();
     int32 last3 ?= pop(); // oops, None returned, go to the catch
-  } fail (empty_error e){
-    printf("The stack is empty\n");
-  } fail (full_error e){
+  } fail (enum full_error e) {
     printf("The stack is full\n");
+  } fail (enum empty_error e) {
+    printf("The stack is empty\n");
   }
 }

--- a/metac-err/trans/MetaC-Err/__tests__/generate-c.spt
+++ b/metac-err/trans/MetaC-Err/__tests__/generate-c.spt
@@ -195,3 +195,64 @@ test goto the matching fail block [[
     }
     attempt_a_finally: {}
   }"
+
+test error function with MaybeError void [[
+  MaybeError<void> f() {}
+  void g() {
+    attempt[a] {
+      void a ?= f();
+    } fail {}
+  }
+]] build generate-c to "
+  typedef union  {
+    void value;
+  } __MaybeError_f;
+  unsigned char f (__MaybeError_f *__maybeErrorReturn_f) {}
+  void g () {
+    {
+      __MaybeError_f __maybe_a;
+      if (!f(&__maybe_a)) {
+        goto attempt_a_fail__;
+      }
+      void a = __maybe_a.value;
+      goto attempt_a_finally;
+    }
+    attempt_a_fail__: {
+      {}
+      goto attempt_a_finally;
+    }
+    attempt_a_finally: {}
+  }"
+
+test error function with MaybeError error as enum [[
+  enum x {A};
+  MaybeError<void, enum x> f() {}
+  void g() {
+    attempt[a] {
+      void a ?= f();
+    } fail (enum x e) {}
+  }
+]] build generate-c to "
+  enum x {A};
+  typedef union  {
+    void value;
+    enum x error;
+  } __MaybeError_f;
+  unsigned char f (__MaybeError_f *__maybeErrorReturn_f) {}
+  void g () {
+    enum x attempt_a_1_e;
+    {
+      __MaybeError_f __maybe_a;
+      if (!f(&__maybe_a)) {
+        attempt_a_1_e = __maybe_a.error;
+        goto attempt_a_fail_1;
+      }
+      void a = __maybe_a.value;
+      goto attempt_a_finally;
+    }
+    attempt_a_fail_1: {
+      {}
+      goto attempt_a_finally;
+    }
+    attempt_a_finally: {}
+  }"

--- a/metac-err/trans/MetaC-Err/__tests__/types.spt
+++ b/metac-err/trans/MetaC-Err/__tests__/types.spt
@@ -1,0 +1,3 @@
+module types
+
+language MetaC

--- a/metac-err/trans/MetaC-Err/names-custom.str
+++ b/metac-err/trans/MetaC-Err/names-custom.str
@@ -10,6 +10,8 @@ imports
   runtime/editor/-
   BaseC/types/-
   BaseC/types/Constructors
+  signatures/BaseC/Expr-sig
+  BaseC/desugar/-
 
   MetaC-Err/constructors
   names/MetaC-Err/names
@@ -17,14 +19,22 @@ imports
 
 rules
 
+  nabl-use-fail(|lang, ctx, uri*):
+    type -> choice
+    where
+      ns := NablNsErrFailGuarded()
+      ; uri := <lookup-uri(|lang, ns)> uri*
+      ; subtasks := <nabl-resolve-all-tasks(|ctx, ns, [Prop(NablProp_err-fail-type(), type, [])])> [uri]
+      ; choice := <task-create-choice(|ctx)> subtasks
+
   nabl-use-site(|lang, ctx, uniques, uris, states) =
     ?d@ErrVarDeclaration(_, _, Call(fn, _))
     // lookup the type of the function variable, FunType(...)
     ; fn-type := <new-task-fixdeps(|ctx, [])> Id(<get-or-create-property-task(|ctx, Type())> fn)
     // Get the error value type
-    ; name := <new-task-fixdeps(|ctx, [fn-type])> Rewrite("err-error-type", fn-type)
+    ; err-type := <new-task-fixdeps(|ctx, [fn-type])> Rewrite("err-error-type", fn-type)
     // lookup the error type that matches a guarded (with parameter) fail block
-    ; task-guard := <nabl-use-candidate(|lang, ctx, uris, name)> UseCandidate(NablNsErrFailGuarded(), [], Current(), True(), [])
+    ; task-guard := <nabl-use-fail(|lang, ctx, uris)> err-type
     // lookup the wildcard failure
     ; task-wildcard := <nabl-use-candidate(|lang, ctx, uris, "_")> UseCandidate(NablNsErrFailWildcard(), [], Current(), True(), [])
     // either of these

--- a/metac-err/trans/MetaC-Err/names.nab
+++ b/metac-err/trans/MetaC-Err/names.nab
@@ -4,14 +4,17 @@ imports
 
   BaseC/desugar/-
   BaseC/names/-
+  MetaC-Err/trans
 
 namespaces
   ErrFailGuarded
   ErrFailWildcard
 
 properties
+
   err-fail-index of ErrFailGuarded
   err-fail-var-name of ErrFailGuarded
+  err-fail-type of ErrFailGuarded
   err-fail-var of Variable
 
 binding rules
@@ -25,11 +28,10 @@ binding rules
     of modifiers Modifiers(mods)
 
   ErrFailGuarded(i, Type(mods, type), Identifier(name), s):
-    // TODO the name should be "i", not the type, but that needs updating in the
-    // nabl-use-site matching for ErrFailGuarded.
-    defines ErrFailGuarded type
+    defines ErrFailGuarded i
       of err-fail-index i
       of err-fail-var-name name
+      of err-fail-type type
     defines Variable name
       of type type
       of err-fail-var True()


### PR DESCRIPTION
The matching for the correct block is done by using a property
constraint. This property is the type of that block.
