### PR TITLE
Fixes #13 - Parse ErrVarDeclarations outside ErrAttemptStatements.

### DIFF
--- a/metac-err/syntax/MetaC-Err.sdf3
+++ b/metac-err/syntax/MetaC-Err.sdf3
@@ -30,24 +30,13 @@ context-free syntax
     [Error([Expr])]
 
 
-  ErrBlockItem =
-    BlockItem
-
-  ErrBlockItem.ErrVarDeclaration =
+  Statement.ErrVarDeclaration =
     [[TypeName] [Identifier] ?= [FunctionCallExpr];]
-
-
-  ErrCompoundStatement.ErrCompoundStatement =
-    [
-    {
-      [{ErrBlockItem "\n"}*]
-    }
-    ]
 
 
   Statement.ErrAttemptStatement =
     [
-    attempt[ErrAttemptLabelName?] [ErrCompoundStatement] [ErrFailGuarded*] [ErrFailWildcard?]
+    attempt[ErrAttemptLabelName?] [CompoundStatement] [ErrFailGuarded*] [ErrFailWildcard?]
     ]
 
 

--- a/metac-err/syntax/__tests__/err.spt
+++ b/metac-err/syntax/__tests__/err.spt
@@ -79,7 +79,7 @@ test attempt statement [[
     FunDef(_, _, _, CompoundStatement([
       ErrAttemptStatement(
         None(),
-        ErrCompoundStatement([]),
+        CompoundStatement([]),
         [],
         Some(ErrFailWildcard(CompoundStatement([])))
       )
@@ -94,7 +94,7 @@ test attempt with fail statement [[
     FunDef(_, _, _, CompoundStatement([
       ErrAttemptStatement(
         None(),
-        ErrCompoundStatement([]),
+        CompoundStatement([]),
         [],
         Some(ErrFailWildcard(ExpressionStatement(_)))
       )
@@ -121,7 +121,7 @@ test unpack value declaration [[
     FunDef(_, _, _, CompoundStatement([
       ErrAttemptStatement(
         None(),
-        ErrCompoundStatement([
+        CompoundStatement([
           ErrVarDeclaration(
             TypeName([UInt8()], None()),
             Identifier("a"),
@@ -146,7 +146,7 @@ test guarded fail blocks [[
     FunDef(_, _, _, CompoundStatement([
       ErrAttemptStatement(
         None(),
-        ErrCompoundStatement([]),
+        CompoundStatement([]),
         [
           ErrFailGuarded(TypeName([Int8()], None()), Identifier("e"), CompoundStatement([])),
           ErrFailGuarded(TypeName([Float32()], None()), Identifier("e"), CompoundStatement([]))

--- a/metac-err/trans/MetaC-Err/__tests__/names.spt
+++ b/metac-err/trans/MetaC-Err/__tests__/names.spt
@@ -64,3 +64,49 @@ test resolve error value variable [[
     }
   }
 ]] resolve #2 to #1
+
+test ?= decl outside attempt should generate an error [[
+  void f() {
+    uint32 x ?= y();
+  }
+]] /should be placed inside an attempt block/
+
+test ?= decl outside/below an attempt should generate an error [[
+  MaybeError<uint32> g() {}
+  void f() {
+    attempt {
+      uint32 x ?= g();
+    } fail {}
+    uint32 x ?= g();
+  }
+]] /should be placed inside an attempt block/
+
+test ?= decl inside a fail {} should generate an error [[
+  MaybeError<uint32> g() {}
+  void f() {
+    attempt {
+    } fail {
+      uint32 x ?= g();
+    }
+  }
+]] /should be placed inside an attempt block/
+
+test ?= decl inside a fail (T e) {} should generate an error [[
+  MaybeError<uint32,uint8> g() {}
+  void f() {
+    attempt {
+    } fail (uint8 e) {
+      uint32 x ?= g();
+    }
+  }
+]] /should be placed inside an attempt block/
+
+test ?= decl inside attempt should not generate an error [[
+  MaybeError<uint32> g() {}
+  void f() {
+    attempt {
+      uint32 x ?= g();
+      if (1) uint32 x2 ?= g();
+    } fail {}
+  }
+]]

--- a/metac-err/trans/MetaC-Err/desugar.str
+++ b/metac-err/trans/MetaC-Err/desugar.str
@@ -5,6 +5,7 @@ imports
   MetaC-Err/constructors
   BaseC/desugar/constructors
   signatures/MetaC-Err-sig
+  signatures/BaseC/-
 
 rules
 
@@ -13,7 +14,7 @@ rules
   desugar05:
     ErrAttemptStatement(
       name,
-      ErrCompoundStatement(items),
+      CompoundStatement(items),
       fails-guarded,
       fails-wildcard
     ) ->

--- a/metac-err/trans/MetaC-Err/names-custom.str
+++ b/metac-err/trans/MetaC-Err/names-custom.str
@@ -8,10 +8,11 @@ imports
   runtime/types/-
   runtime/relations/-
   runtime/editor/-
+
   BaseC/types/-
-  BaseC/types/Constructors
   signatures/BaseC/Expr-sig
-  BaseC/desugar/-
+  signatures/BaseC/Program-sig
+  BaseC/desugar/constructors
 
   MetaC-Err/constructors
   names/MetaC-Err/names
@@ -45,3 +46,16 @@ rules
     ; <replace-annotation(?Use(_) | <new-use(|ctx, task)>)> d
 
   task-rewrite: ("err-error-type", FunType(ErrMaybeError(_, Type(_, err-type), _))) -> err-type
+
+  nabl-constraint(|ctx):
+    Program(_, decls) -> <fail>
+    where
+      msg := $[An attempt-error assignment should be placed inside an attempt block]
+      ; <rec x(
+        // create error if the traversal reaches this node
+        ?e@ErrVarDeclaration(_, _, _) ; task-create-error(|ctx, msg)
+        // traverse into the fail blocks, but not in the main block
+        <+ ?ErrAttemptStatement(_, _, f1, f2) ; <all(try(x))> [f1, f2]
+        // traverse all other nodes
+        <+ all(try(x))
+      )> decls


### PR DESCRIPTION
It now nicely parses, but generates an warning. That makes it more
flexible and gives more information to the programmer that it should be
wrapped with an attempt block.
