### PR TITLE
Fixes #20 - Add array size information to the Array type

### DIFF
--- a/basec/trans/BaseC/desugar/__tests__/declarations.spt
+++ b/basec/trans/BaseC/desugar/__tests__/declarations.spt
@@ -156,7 +156,7 @@ test function declaration [[
           Type([], Int32()),
           Type([], Pointer(Int32())),
           Type([], Pointer(Pointer(Int32))),
-          Type([], Array(Int32))
+          Type([], Array(Int32, None()))
         ]
       )),
       Decl(Identifier("a")),

--- a/basec/trans/BaseC/desugar/__tests__/types.spt
+++ b/basec/trans/BaseC/desugar/__tests__/types.spt
@@ -72,19 +72,25 @@ test pointer type [[
 test array type [[
   int a[];
 ]] run strip-annos to Program(_, [
-    VarDeclaration([], Type([], Array(Int32())), _, _)
+    VarDeclaration([], Type([], Array(Int32(), None())), _, _)
+  ])
+
+test array type with a size [[
+  int a[10];
+]] run strip-annos to Program(_, [
+    VarDeclaration([], Type([], Array(Int32(), Some(10))), _, _)
   ])
 
 test pointer of array type [[
   int *a[];
 ]] run strip-annos to Program(_, [
-    VarDeclaration([], Type([], Pointer(Array(Int32()))), _, _)
+    VarDeclaration([], Type([], Pointer(Array(Int32(), None()))), _, _)
   ])
 
 test pointers of arrays type [[
   int ***a[][];
 ]] run strip-annos to Program(_, [
-    VarDeclaration([], Type([], Pointer(Pointer(Pointer(Array(Array(Int32())))))), _, _)
+    VarDeclaration([], Type([], Pointer(Pointer(Pointer(Array(Array(Int32(), None()), None()))))), _, _)
   ])
 
 test const modifier [[

--- a/basec/trans/BaseC/desugar/constructors.str
+++ b/basec/trans/BaseC/desugar/constructors.str
@@ -20,7 +20,7 @@ signature constructors
     List(Store) -> Storage
 
   Pointer: Type -> Pointer
-  Array: Type -> Array
+  Array: Type * Size -> Array
   Function: Type * Params -> Fun
 
   VarDeclaration:

--- a/basec/trans/BaseC/desugar/types.str
+++ b/basec/trans/BaseC/desugar/types.str
@@ -4,6 +4,7 @@ imports
 
   signatures/BaseC/-
   BaseC/desugar/constructors
+  BaseC/utils/numbers
 
 rules
 
@@ -49,10 +50,13 @@ rules
   find-decl =
     oncetd(?Decl(_) ; ?d) ; !d
 
+  desugar-array-size: None() -> None()
+  desugar-array-size: Some(value) -> Some(<number-to-int> value)
+
   merge-types:
-    (Type(mods, type), ptr, ArrayDecl(d, _)) -> t
+    (Type(mods, type), ptr, ArrayDecl(d, size)) -> t
     where
-      t := <merge-types> (Type(mods, Array(type)), ptr, d)
+      t := <merge-types> (Type(mods, Array(type, <desugar-array-size> size)), ptr, d)
 
   merge-types:
     (base-type@Type(mods, type), Some(Pointer(qualifiers, ptr)), decl) -> t

--- a/basec/trans/BaseC/generate/__tests__/declarations.spt
+++ b/basec/trans/BaseC/generate/__tests__/declarations.spt
@@ -6,6 +6,22 @@ test variable declarations [[
   int32 a,b,c;
 ]] build generate-c to "signed int a; signed int b; signed int c;"
 
+test array variable without an array size [[
+  int32 a[];
+]] build generate-c to "signed int a[];"
+
+test array variable with an array size [[
+  int32 a[10];
+]] build generate-c to "signed int a[10];"
+
+test array variable with an octal array size [[
+  int32 a[010];
+]] build generate-c to "signed int a[8];"
+
+test array variable with an hex array size [[
+  int32 a[0x10];
+]] build generate-c to "signed int a[16];"
+
 test block initializers [[
   static int32 a[] = {1,2,3};
 ]] build generate-c to "static signed int a[] = {1, 2, 3};"

--- a/basec/trans/BaseC/generate/__tests__/expressions.spt
+++ b/basec/trans/BaseC/generate/__tests__/expressions.spt
@@ -7,5 +7,5 @@ test comma expression [[
 ]] build generate-c to "signed int a = (1, 2, 3);"
 
 test desugar cast types [[
-  uint64 **a = [[(unsigned long * const *) 1]];
+  uint64 **a = (unsigned long * const *) 1;
 ]] build generate-c to "unsigned long** a = (const unsigned long **) 1;"

--- a/basec/trans/BaseC/generate/declarations.str
+++ b/basec/trans/BaseC/generate/declarations.str
@@ -17,7 +17,7 @@ strategies
     )
 
   generate-Declarator-pointer-type:
-    Array(t) -> <generate-Declarator-pointer-type> t
+    Array(t, _) -> <generate-Declarator-pointer-type> t
 
   generate-Declarator-pointer-type:
     Function(t, _) -> <generate-Declarator-pointer-type> t
@@ -29,7 +29,7 @@ strategies
     t -> None()
 
   generate-Declarator-decl:
-    (Array(t), decl) -> ArrayDecl(<generate-Declarator-decl> (t, decl), /* todo restore size */ None())
+    (Array(t, s), decl) -> ArrayDecl(<generate-Declarator-decl> (t, decl), <generate-array-size> s)
 
   generate-Declarator-decl:
     (Function(t, ps), decl) -> FuncDecl(
@@ -51,6 +51,9 @@ strategies
 
   generate-Initializer:
     (decl, None()) -> decl
+
+  generate-array-size: None() -> None()
+  generate-array-size: Some(value) -> Some(Integer(<int-to-string> value))
 
   generate:
     VarDeclaration(storage, type, name, init)

--- a/basec/trans/BaseC/types/Constants.str
+++ b/basec/trans/BaseC/types/Constants.str
@@ -3,9 +3,11 @@ module BaseC/types/Constants
 imports
 
   signatures/BaseC/-
+  BaseC/desugar/constructors
   BaseC/types/Constructors
   runtime/types/-
   metac-runtime-utils/in-range
+  metac-runtime-utils/string
 
 rules
 
@@ -38,11 +40,9 @@ rules
   create-type-task(|ctx):
     Null() -> <type-is(|ctx)> Null()
 
+  // subtract 2 from the string length, which are the opening/closing quotes "
   create-type-task(|ctx):
-    String(s) -> <type-is(|ctx)> Array(UInt8())
-
-  string-drop-last(|n) =
-    string-as-chars(reverse ; drop(|n) ; reverse)
+    String(s) -> <type-is(|ctx)> Array(UInt8(), Some(<subt> (<string-length> s, 2)))
 
   str-in-range(|min, max): strVal ->
     <try(string-to-int) ; in-range(|min, max)> strVal
@@ -62,9 +62,10 @@ rules
   is-uint32 = str-in-range(|0, 4294967295); !UInt32()
   is-uint64 =
     (
-      string-ends-with(|"LU")
-      <+ string-ends-with(|"LLU")
+      string-ends-with(|"LLU")
       <+ string-ends-with(|"ULL")
+      <+ string-ends-with(|"LU")
+      <+ string-ends-with(|"UL")
     )
     ; !UInt64()
 

--- a/basec/trans/BaseC/types/Constructors.str
+++ b/basec/trans/BaseC/types/Constructors.str
@@ -2,9 +2,6 @@ module BaseC/types/Constructors
 
 signature constructors
 
-  Array: TypeKind -> TypeKind
-  Array: TypeKind
-
   Int: TypeKind
   Numeric: TypeKind
   Str: TypeKind

--- a/basec/trans/BaseC/types/Declarations.ts
+++ b/basec/trans/BaseC/types/Declarations.ts
@@ -17,14 +17,29 @@ relations
   // errors. The actual implementation is in the .str file.
   None() <is-assignable: None()
 
+  // further defined in type-relations
+  0 <lt: 1
+
+type functions
+
+  // defined further in type-functions.str
+  length: [] -> 0
+
 type rules
 
-  BlockInitializer([]): Array(Int32())
-  BlockInitializer([x | _]): Array(t)
+  BlockInitializer([]): Array(Int32(), Some(0))
+  BlockInitializer(b@[x | _]): Array(t, Some(len))
     where x : t
+    and <length> b => len
 
   d@VarDeclaration(_, _, _, Some(init)) :-
     where init : it
       and definition of d : t
       and (it <is-assignable: t)
         else error $[Incompatible types when initializing variable of type [t] using an expression of type [it]] on init
+      or (
+        it => Array(_, Some(init-array-size))
+        and t => Array(_, Some(decl-array-size))
+        and not (decl-array-size <lt: init-array-size)
+          else error $[excess elements in array initializer] on init
+      )

--- a/basec/trans/BaseC/types/Expressions.ts
+++ b/basec/trans/BaseC/types/Expressions.ts
@@ -121,7 +121,7 @@ type rules
 
   ArrayField(e, index): t'
     where (
-        e: Array(t)
+        e: Array(t, _)
         or e: Pointer(t)
       )
       and <resolve-typedefs> t => t'

--- a/basec/trans/BaseC/types/__tests__/constants.spt
+++ b/basec/trans/BaseC/types/__tests__/constants.spt
@@ -19,6 +19,38 @@ test smallest-int-type
     [Int8(), Int16(), UInt8(), UInt64()]
 */
 
+test 1LLU should be UInt64() [[
+  void f() { [[(0,1LLU)]]; }
+]] run get-type to UInt64()
+
+test 1ULL should be UInt64() [[
+  void f() { [[(0,1ULL)]]; }
+]] run get-type to UInt64()
+
+test 1UL should be UInt64() [[
+  void f() { [[(0,1UL)]]; }
+]] run get-type to UInt64()
+
+test 1LU should be UInt64() [[
+  void f() { [[(0,1LU)]]; }
+]] run get-type to UInt64()
+
+test 1U should be UInt8() [[
+  void f() { [[(0,1U)]]; }
+]] run get-type to UInt8()
+
+test 255U should be UInt8 [[
+  void f() { [[(0,255U)]]; }
+]] run get-type to UInt8()
+
+test 256U should be UInt16, as it doesn't fit in uint8 [[
+  void f() { [[(0,256U)]]; }
+]] run get-type to UInt16()
+
+test 255 should be Int16 [[
+  void f() { [[(0,255)]]; }
+]] run get-type to Int16()
+
 test get type of a constant integer [[
   int32 f() { return [[(0,1)]]; }
 ]] run get-type to Int8()
@@ -29,7 +61,7 @@ test get type of a char [[
 
 test get type of a char [[
   uint8 * f() { return [[(0,"ab")]]; }
-]] run get-type to Array(UInt8())
+]] run get-type to Array(UInt8(), Some(2))
 
 test get type or bool [[
   uint8 f() { return [[true]]; }

--- a/basec/trans/BaseC/types/__tests__/declarations.spt
+++ b/basec/trans/BaseC/types/__tests__/declarations.spt
@@ -10,6 +10,10 @@ test init declaration check [[
   int32 a[] = {1};
 ]] 0 errors
 
+test init declaration block type [[
+  uint8 a[] = [[{'a', 'b'}]];
+]] run get-type to Array(UInt8(), Some(2))
+
 test init declaration check [[
   int32 a = {1};
 ]] 1 errors
@@ -21,3 +25,19 @@ test init declaration check [[
 test init declaration check [[
   int32 a = {{1}};
 ]] 1 errors
+
+test no excess array elements error in init block with an empty block [[
+  int32 a[0] = {};
+]] 0 errors
+
+test excess array elements in init block when init block size is 2 and array size is 1 [[
+  int32 a[1] = {1, 2};
+]] 1 errors
+
+test no excess array elements errors when both sizes are 2 [[
+  int32 a[2] = {1, 2};
+]] 0 errors
+
+test no excess array elements errors when array size > than init block [[
+  int32 a[3] = {1, 2};
+]] 0 errors

--- a/basec/trans/BaseC/types/__tests__/typedefs.spt
+++ b/basec/trans/BaseC/types/__tests__/typedefs.spt
@@ -34,7 +34,7 @@ test typedef pointer of a base type with array [[
   typedef int32 *** a[];
   a y;
   a z = [[(0,y)]];
-]] run get-type to Pointer(Pointer(Pointer(Array(Int32()))))
+]] run get-type to Pointer(Pointer(Pointer(Array(Int32(), None()))))
 
 test typedef of another typedef with pointer [[
   typedef int32 a;

--- a/basec/trans/BaseC/types/__tests__/types.spt
+++ b/basec/trans/BaseC/types/__tests__/types.spt
@@ -10,17 +10,17 @@ test pointer type [[
 test array type [[
   int32 a[];
   int32 b[] = [[a]];
-]] run get-type to Array(Int32)
+]] run get-type to Array(Int32, None())
 
 test multi dimensional array type [[
   int32 a[][];
   int32 b[][] = [[a]];
-]] run get-type to Array(Array(Int32))
+]] run get-type to Array(Array(Int32, None()), None())
 
 test pointer to array type [[
   int32 *a[];
   int32 *b[] = [[a]];
-]] run get-type to Pointer(Array(Int32))
+]] run get-type to Pointer(Array(Int32, None()))
 
 test function type [[
   int32 a();

--- a/basec/trans/BaseC/types/relation-is-assignable.str
+++ b/basec/trans/BaseC/types/relation-is-assignable.str
@@ -23,8 +23,8 @@ rules
       from-base := <create-base-type-task(|ctx)> from;
       to-base := <create-base-type-task(|ctx)> to;
 
-      // resolve all typedefs, so Array(Typedef(){(Type, Pointer(UInt32))})
-      // becomes Array(Pointer(UInt32))
+      // resolve all typedefs, so Array(Typedef(){(Type, Pointer(UInt32))}, _)
+      // becomes Array(Pointer(UInt32), _)
       from-resolved := <create-resolve-typedef-task(|ctx)> from;
       to-resolved := <create-resolve-typedef-task(|ctx)> to;
 
@@ -33,7 +33,7 @@ rules
       from-structure := <create-rewrite-type-structure-task(|ctx)> from-resolved;
       to-structure := <create-rewrite-type-structure-task(|ctx)> to-resolved;
 
-      // basically Array(t) is the same as Pointer(t), so rewrite Array(t) to Pointer(t)
+      // basically Array(t, _) is the same as Pointer(t), so rewrite Array(t, _) to Pointer(t)
       // that means, you can assign an array to a pointer
       from-array-structure := <create-rewrite-type-array-to-pointer(|ctx)> from-structure;
 

--- a/basec/trans/BaseC/types/type-functions.str
+++ b/basec/trans/BaseC/types/type-functions.str
@@ -1,0 +1,5 @@
+module BaseC/types/type-functions
+
+rules
+
+  type-func-length(|ctx) = length

--- a/basec/trans/BaseC/types/type-relations.str
+++ b/basec/trans/BaseC/types/type-relations.str
@@ -1,0 +1,16 @@
+module BaseC/types/type-relations
+
+imports
+
+  runtime/task/tasks
+
+signature constructors
+
+  Lt : Term * Term -> Instruction
+
+rules
+
+  relation-match-custom(|ctx):
+    ("<lt:", lhs, rhs) -> <new-task(|ctx)> Lt(lhs, rhs)
+
+  perform-task(|task-id): Lt(lhs, rhs) -> <lt> (lhs, rhs)

--- a/basec/trans/BaseC/types/typedefs.str
+++ b/basec/trans/BaseC/types/typedefs.str
@@ -15,7 +15,7 @@ rules
 
   get-typedef-base-type: t -> <<get-type-transform ; get-typedef-base-type> t <+ !t>
 
-  get-type-transform: Array(t) -> t
+  get-type-transform: Array(t, _) -> t
   get-type-transform: Pointer(t) -> t
   get-type-transform: t@TypedefName(_) -> <get-type> t
 
@@ -32,10 +32,10 @@ rules
   task-rewrite: ("type-structure", t) -> <topdown(try(not(is-type-structure) ; !Int()))> t
 
   is-type-structure: t@Pointer(_) -> t
-  is-type-structure: t@Array(_) -> t
+  is-type-structure: t@Array(_, _) -> t
 
   create-rewrite-type-array-to-pointer(|ctx) = task-create-rewrite(|ctx, "type-array-as-pointer")
-  task-rewrite: ("type-array-as-pointer", t) -> <topdown(try(\ Array(t) -> Pointer(t) \))> t
+  task-rewrite: ("type-array-as-pointer", t) -> <topdown(try(\ Array(t, _) -> Pointer(t) \))> t
 
   type-func-resolve-typedefs(|ctx):
     t -> <task-create-id(|ctx, rewrite')> rewrite'

--- a/basec/trans/BaseC/utils/numbers.str
+++ b/basec/trans/BaseC/utils/numbers.str
@@ -1,0 +1,32 @@
+module BaseC/utils/numbers
+
+imports
+
+  signatures/BaseC/Constants-sig
+  metac-runtime-utils/string
+
+rules
+
+  number-to-int:
+    Integer(value)
+    -> <strip-number-suffix ; string-to-int> value
+
+  number-to-int:
+    Octal(value)
+    -> <strip-number-suffix ; explode-string ; oct-chars-to-int> value
+
+  number-to-int:
+    Hexadecimal(value)
+    -> <strip-number-suffix ; explode-string ; drop(|2) ; hex-chars-to-int> value
+
+  strip-number-suffix =
+    ?value
+    ; (
+      string-ends-with(|"ULL") ; <string-drop-last(|3)> value
+      <+ string-ends-with(|"LLU") ; <string-drop-last(|3)> value
+      <+ string-ends-with(|"UL") ; <string-drop-last(|2)> value
+      <+ string-ends-with(|"LU") ; <string-drop-last(|2)> value
+      <+ string-ends-with(|"L") ; <string-drop-last(|1)> value
+      <+ string-ends-with(|"U") ; <string-drop-last(|1)> value
+      <+ !value
+    )

--- a/basec/trans/BaseC/utils/types.str
+++ b/basec/trans/BaseC/utils/types.str
@@ -8,7 +8,7 @@ imports
 
 rules
 
-  get-base-type: Array(t) -> <get-base-type> t
+  get-base-type: Array(t, _) -> <get-base-type> t
   get-base-type: Pointer(t) -> <get-base-type> t
   get-base-type: Function(t, _) -> <get-base-type> t
   get-base-type: t -> t

--- a/metac-runtime-utils/trans/metac-runtime-utils/string.str
+++ b/metac-runtime-utils/trans/metac-runtime-utils/string.str
@@ -28,4 +28,7 @@ strategies
       ; res := <internal-strip-string-first> (xs, ys)
       <+
       res := [y | ys]
-  
+
+  // removes the last n characters from a string
+  string-drop-last(|n) =
+    string-as-chars(reverse ; drop(|n) ; reverse)


### PR DESCRIPTION
Fixes #20.
- Now `int a[10];` also generates `int a[10];` including the array size
- Init block sizes are type checked for their size
  `int a[2] = {1,2,3}` generates an error
- Now correctly finds the type of constant `1UL` as `UInt64()`.
